### PR TITLE
Update Asset Model

### DIFF
--- a/SnipeSharp/Endpoints/Models/Asset.cs
+++ b/SnipeSharp/Endpoints/Models/Asset.cs
@@ -53,7 +53,7 @@ namespace SnipeSharp.Endpoints.Models
         public string Notes { get; set; }
 
         [JsonProperty("company")]
-        [OptionalRequestHeader("company")]
+        [OptionalRequestHeader("company_id")]
         public Company Company { get; set; }
 
         [JsonProperty("location")]


### PR DESCRIPTION
Changed the OptionalRequestHeader for Company to Company_id.
This is so that when the asset is created a company can be assigned to it.