### PR TITLE
Actually GetAll when there are fewer than 1000 entries and FindAll when a limit is not provided

### DIFF
--- a/SnipeSharp/Attributes/EndpointObjectNotFoundMessage.cs
+++ b/SnipeSharp/Attributes/EndpointObjectNotFoundMessage.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace SnipeSharp.Attributes
+{
+    /// <summary>
+    /// Since the SnipeIT Api uses inconsistent error string to note whether or not an object exists or not, we can use this attribute to declare it.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public class EndpointObjectNotFoundMessage : Attribute
+    {
+        public string Message { get; private set; }
+        public EndpointObjectNotFoundMessage(string notFoundMessage)
+        {
+            Message = notFoundMessage;
+        }
+    }
+}

--- a/SnipeSharp/Endpoints/EndPointManager.cs
+++ b/SnipeSharp/Endpoints/EndPointManager.cs
@@ -112,7 +112,7 @@ namespace SnipeSharp.Endpoints
         {
             string response = _reqManager.Get(_endPoint, filter);
             ResponseCollection<T> result = JsonConvert.DeserializeObject<ResponseCollection<T>>(response);
-            return (result.Rows != null) ? result.Rows[0] : default(T);
+            return (result.Rows != null && result.Rows.Count > 0) ? result.Rows[0] : default(T);
         }
 
         /// <summary>

--- a/SnipeSharp/Endpoints/EndPointManager.cs
+++ b/SnipeSharp/Endpoints/EndPointManager.cs
@@ -40,9 +40,7 @@ namespace SnipeSharp.Endpoints
             // If there are more than 1000 assets split up the requests to avoid timeouts
             if (count.Total < 1000)
             {
-                string response = _reqManager.Get(_endPoint);
-                ResponseCollection<T> results = JsonConvert.DeserializeObject<ResponseCollection<T>>(response);
-                return results;
+                return FindAll(new SearchFilter { Limit = (int) count.Total });
 
             } else
             {

--- a/SnipeSharp/Endpoints/EndPointManager.cs
+++ b/SnipeSharp/Endpoints/EndPointManager.cs
@@ -79,8 +79,26 @@ namespace SnipeSharp.Endpoints
         /// <returns></returns>
         public ResponseCollection<T> FindAll(ISearchFilter filter)
         {
-            string response = _reqManager.Get(_endPoint, filter);
-            ResponseCollection<T> results = JsonConvert.DeserializeObject<ResponseCollection<T>>(response);
+            var response = _reqManager.Get(_endPoint, filter);
+            var results = JsonConvert.DeserializeObject<ResponseCollection<T>>(response);
+
+            // If there is no limit and there are more total than retrieved
+            if(filter.Limit == null && results.Rows.Count < results.Total)
+            {
+                filter.Limit = 1000;
+                filter.Offset = (filter.Offset == null ? 0 : filter.Offset) + results.Rows.Count;
+                
+                while (results.Rows.Count < results.Total)
+                {
+                    response = _reqManager.Get(_endPoint, filter);
+                    var batch = JsonConvert.DeserializeObject<ResponseCollection<T>>(response);
+
+                    results.Rows.AddRange(batch.Rows);
+
+                    filter.Offset += 1000;
+                }
+            }
+
             return results;
         }
 

--- a/SnipeSharp/Endpoints/EndPointManager.cs
+++ b/SnipeSharp/Endpoints/EndPointManager.cs
@@ -82,13 +82,14 @@ namespace SnipeSharp.Endpoints
             var response = _reqManager.Get(_endPoint, filter);
             var results = JsonConvert.DeserializeObject<ResponseCollection<T>>(response);
 
+            var baseOffset = filter.Offset == null ? 0 : filter.Offset;
             // If there is no limit and there are more total than retrieved
-            if(filter.Limit == null && results.Rows.Count < results.Total)
+            if(filter.Limit == null && baseOffset + results.Rows.Count < results.Total)
             {
                 filter.Limit = 1000;
-                filter.Offset = (filter.Offset == null ? 0 : filter.Offset) + results.Rows.Count;
+                filter.Offset = baseOffset + results.Rows.Count;
                 
-                while (results.Rows.Count < results.Total)
+                while (baseOffset + results.Rows.Count < results.Total)
                 {
                     response = _reqManager.Get(_endPoint, filter);
                     var batch = JsonConvert.DeserializeObject<ResponseCollection<T>>(response);

--- a/SnipeSharp/Endpoints/Models/Accessory.cs
+++ b/SnipeSharp/Endpoints/Models/Accessory.cs
@@ -4,6 +4,7 @@ using SnipeSharp.Attributes;
 
 namespace SnipeSharp.Endpoints.Models
 {
+    [EndpointObjectNotFoundMessage("Accessory not found")]
     public class Accessory : CommonEndpointModel
     {
         [JsonProperty("company")]

--- a/SnipeSharp/Endpoints/Models/Asset.cs
+++ b/SnipeSharp/Endpoints/Models/Asset.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 namespace SnipeSharp.Endpoints.Models
 {
     // TODO: Make constructor that forces required fields
+    [EndpointObjectNotFoundMessage("Asset not found")]
     public class Asset : CommonEndpointModel
     {
 

--- a/SnipeSharp/Endpoints/Models/Category.cs
+++ b/SnipeSharp/Endpoints/Models/Category.cs
@@ -5,6 +5,7 @@ using SnipeSharp.Exceptions;
 
 namespace SnipeSharp.Endpoints.Models
 {
+    [EndpointObjectNotFoundMessage("Category not found")]
     public class Category : CommonEndpointModel
     {
         [JsonProperty("image")]

--- a/SnipeSharp/Endpoints/Models/Company.cs
+++ b/SnipeSharp/Endpoints/Models/Company.cs
@@ -1,8 +1,10 @@
-﻿using SnipeSharp.Common;
+﻿using SnipeSharp.Attributes;
+using SnipeSharp.Common;
 using Newtonsoft.Json;
 
 namespace SnipeSharp.Endpoints.Models
 {
+    [EndpointObjectNotFoundMessage("Company not found")]
     public class Company : CommonEndpointModel
     {
         [JsonProperty("image")]

--- a/SnipeSharp/Endpoints/Models/Component.cs
+++ b/SnipeSharp/Endpoints/Models/Component.cs
@@ -4,6 +4,7 @@ using SnipeSharp.Attributes;
 
 namespace SnipeSharp.Endpoints.Models
 {
+    [EndpointObjectNotFoundMessage("Component not found")]
     public class Component : CommonEndpointModel
     {
         [JsonProperty("serial_number")]

--- a/SnipeSharp/Endpoints/Models/Consumable.cs
+++ b/SnipeSharp/Endpoints/Models/Consumable.cs
@@ -4,6 +4,7 @@ using SnipeSharp.Common;
 
 namespace SnipeSharp.Endpoints.Models
 {
+    [EndpointObjectNotFoundMessage("Consumable not found")]
     public class Consumable : CommonEndpointModel
     {
         [JsonProperty("category")]

--- a/SnipeSharp/Endpoints/Models/Department.cs
+++ b/SnipeSharp/Endpoints/Models/Department.cs
@@ -4,6 +4,7 @@ using SnipeSharp.Attributes;
 
 namespace SnipeSharp.Endpoints.Models
 {
+    [EndpointObjectNotFoundMessage("Department not found")]
     public class Department : CommonEndpointModel
     {
         [JsonProperty("company_id")]

--- a/SnipeSharp/Endpoints/Models/Depreciation.cs
+++ b/SnipeSharp/Endpoints/Models/Depreciation.cs
@@ -4,6 +4,7 @@ using SnipeSharp.Attributes;
 
 namespace SnipeSharp.Endpoints.Models
 {
+    [EndpointObjectNotFoundMessage("Depreciation not found")]
     public class Depreciation : CommonEndpointModel
     {
 

--- a/SnipeSharp/Endpoints/Models/FieldSet.cs
+++ b/SnipeSharp/Endpoints/Models/FieldSet.cs
@@ -1,8 +1,10 @@
-﻿using SnipeSharp.Common;
+﻿using SnipeSharp.Attributes;
+using SnipeSharp.Common;
 using Newtonsoft.Json;
 
 namespace SnipeSharp.Endpoints.Models
 {
+    [EndpointObjectNotFoundMessage("Fieldset does not exist")]
     public class FieldSet : CommonEndpointModel
     {
         [JsonProperty("fields")]

--- a/SnipeSharp/Endpoints/Models/License.cs
+++ b/SnipeSharp/Endpoints/Models/License.cs
@@ -1,8 +1,10 @@
 ﻿using Newtonsoft.Json;
+using SnipeSharp.Attributes;
 using SnipeSharp.Common;
 
 namespace SnipeSharp.Endpoints.Models
 {
+    [EndpointObjectNotFoundMessage("License not found")]
     public class License : CommonEndpointModel
     {
  

--- a/SnipeSharp/Endpoints/Models/Location.cs
+++ b/SnipeSharp/Endpoints/Models/Location.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 
 namespace SnipeSharp.Endpoints.Models
 {
+    [EndpointObjectNotFoundMessage("Location not found")]
     public class Location : CommonEndpointModel
     {
         [JsonProperty("image")]

--- a/SnipeSharp/Endpoints/Models/Manufacturer.cs
+++ b/SnipeSharp/Endpoints/Models/Manufacturer.cs
@@ -5,7 +5,7 @@ using SnipeSharp.Common;
 namespace SnipeSharp.Endpoints.Models
 {
 
-
+    [EndpointObjectNotFoundMessage("Manufacturer not found")]
     public class Manufacturer : CommonEndpointModel
     {
         [JsonProperty("url")]

--- a/SnipeSharp/Endpoints/Models/Model.cs
+++ b/SnipeSharp/Endpoints/Models/Model.cs
@@ -4,6 +4,7 @@ using SnipeSharp.Common;
 
 namespace SnipeSharp.Endpoints.Models
 {
+    [EndpointObjectNotFoundMessage("AssetModel not found")]
     public class Model : CommonEndpointModel
     {
 

--- a/SnipeSharp/Endpoints/Models/StatusLabel.cs
+++ b/SnipeSharp/Endpoints/Models/StatusLabel.cs
@@ -6,6 +6,7 @@ using SnipeSharp.Exceptions;
 
 namespace SnipeSharp.Endpoints.Models
 {
+    [EndpointObjectNotFoundMessage("Statuslabel not found")]
     public class StatusLabel : CommonEndpointModel
     {
         private string _type;

--- a/SnipeSharp/Endpoints/Models/Supplier.cs
+++ b/SnipeSharp/Endpoints/Models/Supplier.cs
@@ -4,6 +4,7 @@ using SnipeSharp.Attributes;
 
 namespace SnipeSharp.Endpoints.Models
 {
+    [EndpointObjectNotFoundMessage("Supplier not found")]
     public class Supplier : CommonEndpointModel
     {
         [JsonProperty("name")]

--- a/SnipeSharp/Endpoints/Models/User.cs
+++ b/SnipeSharp/Endpoints/Models/User.cs
@@ -5,6 +5,7 @@ using SnipeSharp.Attributes;
 
 namespace SnipeSharp.Endpoints.Models
 {
+    [EndpointObjectNotFoundMessage("User not found")]
     public class User : CommonEndpointModel
     {
 

--- a/SnipeSharp/SnipeSharp.csproj
+++ b/SnipeSharp/SnipeSharp.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes\EndpointObjectNotFoundMessage.cs" />
     <Compile Include="Attributes\FilterParamName.cs" />
     <Compile Include="Attributes\OptionalRequestHeader.cs" />
     <Compile Include="Attributes\RequiredRequestHeader.cs" />


### PR DESCRIPTION
Discovered while testing against the asset list on a local SnipeIT install.

In EndPointManager.GetAll, when there are fewer than 1000 assets in the system, only 50 assets (the default limit) would be included in the ResponseCollection, though the Total would still show the correct number.

In EndPointManager.FindAll, when a limit is not provided, again at most only 50 assets would be included in the ResponseCollection, even when the results should have more, such as when retrieving all assets of a certain manufacturer.

### Replication steps
I did my testing in PowerShell.

1. Have a SnipeIT instance with more than 50 but fewer than 1000 assets, where approximately 160 of those assets have a manufacturer.
2. PowerShell log attached (paths removed):

```powershell
PS C:\> $api = [SnipeSharp.SnipeItApi]::new(); $api.ApiSettings.ApiToken = $token; $api.ApiSettings.BaseUrl = $url
PS C:\> $api.AssetManager.GetAll() | select Total, @{Name='Actual';Expression={$_.Rows.Count}}

Total Actual
----- ------
  602     50

PS C:\> $filter = [SnipeSharp.Endpoints.SearchFilters.AssetSearchFilter]::new()
PS C:\> $filter.Manufacturer = $api.ManufacturerManager.Get("Lenovo")
PS C:\> $api.ManufacturerManager.Get("Lenovo").AssetsCount
167
PS C:\> $api.AssetManager.FindAll($filter) | select Total, @{Name='Actual';Expression={$_.Rows.Count}}

Total Actual
----- ------
  167     50

```