### PR TITLE
Removed Name fields from Asset/User which were duplicates from base class

### DIFF
--- a/SnipeSharp/Endpoints/Models/Asset.cs
+++ b/SnipeSharp/Endpoints/Models/Asset.cs
@@ -12,11 +12,6 @@ namespace SnipeSharp.Endpoints.Models
     // TODO: Make constructor that forces required fields
     public class Asset : CommonEndpointModel
     {
-
-        [JsonProperty("name")]
-        [OptionalRequestHeader("name")]
-        public new string Name { get; set; }
-
         [JsonProperty("asset_tag")]
         [RequiredRequestHeader("asset_tag")]
         public string AssetTag { get; set; }

--- a/SnipeSharp/Endpoints/Models/User.cs
+++ b/SnipeSharp/Endpoints/Models/User.cs
@@ -7,11 +7,6 @@ namespace SnipeSharp.Endpoints.Models
 {
     public class User : CommonEndpointModel
     {
-
-        [JsonProperty("name")]
-        [OptionalRequestHeader("name")]
-        public new string Name { get; set; }
-
         [JsonProperty("accessories_count")]
         public long? AccessoriesCount { get; set; }
 


### PR DESCRIPTION
The Name field from CommonEndpointModel was duplicated in Asset and User, causing NullReferenceExceptions in EndPointManager.Get(string) when looking up assets and users by name.

If the object is serialized or dumped to a PowerShell console, everything appears fine, but because the underlying fields are not the same and that method treats them as CommonEndpointModels, the lookup would fail.

```powershell
PS C:\> $api.AssetManager.Get("Asset15")
Exception calling "Get" with "1" argument(s): "Object reference not set to an instance of an object."
At line:1 char:1
+ $api.AssetManager.Get("Asset15")
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : NullReferenceException
PS C:\> $Error[0].Exception.InnerException.StackTrace
   at SnipeSharp.Endpoints.EndPointManager`1.<>c__DisplayClass7_0.<Get>b__0(T i) in C:\Repositories\SnipeSharp\SnipeSharp\Endpoints\EndPointManager.cs:line 127
   at System.Linq.Enumerable.WhereListIterator`1.MoveNext()
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source)
   at SnipeSharp.Endpoints.EndPointManager`1.Get(String name) in C:\Repositories\SnipeSharp\SnipeSharp\Endpoints\EndPointManager.cs:line 127
   at CallSite.Target(Closure , CallSite , Object , String )
```