### PR TITLE
Updated tests to reflect the use of RequestManagerRestSharp over RequestManager.

### DIFF
--- a/SnipeSharp.Tests/RequestManagerTests.cs
+++ b/SnipeSharp.Tests/RequestManagerTests.cs
@@ -4,6 +4,8 @@ using SnipeSharp.Exceptions;
 using SnipeSharp.Common;
 using System.Reflection;
 using System.Net.Http;
+using RestSharp;
+using RestSharp.Authenticators;
 
 namespace SnipeSharp.Tests
 {
@@ -31,37 +33,36 @@ namespace SnipeSharp.Tests
         [TestMethod]
         public void CheckApiTokenAndUrl_SetHttpClientBaseAddress_SetCorrectly()
         {
-            SnipeItApi snipe = new SnipeItApi();
-            Uri url = new Uri("http://google.com");
+            var snipe = new SnipeItApi();
+            var url = new Uri("http://google.com");
             snipe.ApiSettings.ApiToken = "xxxxx";
             snipe.ApiSettings.BaseUrl = url;
             snipe.ReqManager.CheckApiTokenAndUrl();
 
             // Get the Static property value
-            Type type = typeof(RequestManager);
-            FieldInfo prop = type.GetField("Client", BindingFlags.NonPublic | BindingFlags.Static);
-            HttpClient value = prop.GetValue(snipe.ReqManager) as HttpClient;
+            var prop = typeof(RequestManagerRestSharp).GetField("Client", BindingFlags.NonPublic | BindingFlags.Static);
+            var client = prop.GetValue(snipe.ReqManager) as RestClient;
 
-            Assert.AreEqual(url, value.BaseAddress);
+            Assert.AreEqual<Uri>(url, client.BaseUrl);
         }
 
         [TestMethod]
         public void CheckApiTokenAndUrl_SetAuthorizationHeader_SetCorrectly()
         {
-            SnipeItApi snipe = new SnipeItApi();
-            Uri url = new Uri("http://google.com");
+            var snipe = new SnipeItApi();
+            var url = new Uri("http://google.com");
             snipe.ApiSettings.ApiToken = "xxxxx";
             snipe.ApiSettings.BaseUrl = url;
             snipe.ReqManager.CheckApiTokenAndUrl();
 
             // Get the Static property value
-            Type type = typeof(RequestManager);
-            FieldInfo prop = type.GetField("Client", BindingFlags.NonPublic | BindingFlags.Static);
-            HttpClient value = prop.GetValue(snipe.ReqManager) as HttpClient;
+            var prop = typeof(RequestManagerRestSharp).GetField("Client", BindingFlags.NonPublic | BindingFlags.Static);
+            var client = prop.GetValue(snipe.ReqManager) as RestClient;
 
-            Assert.IsTrue(value.DefaultRequestHeaders.Authorization.Scheme == "Bearer" &&
-                value.DefaultRequestHeaders.Authorization.Parameter == "xxxxx");
-
+            // NOTE: This test depends on the internal implementation of RestSharp not changing. Check there if you update that dependency!
+            var value = new PrivateObject(client.Authenticator).GetField("authorizationValue") as string;
+            
+            Assert.AreEqual<string>("Bearer xxxxx", value);
         }
     }
 }

--- a/SnipeSharp.Tests/SnipeSharp.Tests.csproj
+++ b/SnipeSharp.Tests/SnipeSharp.Tests.csproj
@@ -47,6 +47,9 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="RestSharp, Version=106.1.0.0, Culture=neutral, PublicKeyToken=598062e77f915f75, processorArchitecture=MSIL">
+      <HintPath>..\packages\RestSharp.106.1.0\lib\net452\RestSharp.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />

--- a/SnipeSharp/Properties/AssemblyInfo.cs
+++ b/SnipeSharp/Properties/AssemblyInfo.cs
@@ -37,4 +37,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyFileVersion("0.1.2.0")]
 [assembly: AssemblyInformationalVersion("0.1.2")]
 [assembly: NeutralResourcesLanguage("en")]
-
+[assembly: InternalsVisibleTo("SnipeSharp.Tests")]


### PR DESCRIPTION
The use of RequestManagerRestSharp in SnipeItApi was causing the tests CheckApiTokenAndUrl_SetAuthorizationHeader_SetCorrectly and CheckApiTokenAndUrl_SetHttpClientBaseAddress_SetCorrectly to fail with NullReferenceExceptions.

I updated the tests to reflect the use of the new class, and added internals visibility on the main assembly to the test assembly, to limit how much reflection we need to do.