### PR TITLE
Added ByTag and BySerial lookup to AssetEndpointManager.

### DIFF
--- a/SnipeSharp/Endpoints/ExtendedManagers/AssetEndpointManager.cs
+++ b/SnipeSharp/Endpoints/ExtendedManagers/AssetEndpointManager.cs
@@ -27,5 +27,18 @@ namespace SnipeSharp.Endpoints.ExtendedManagers
             return result;
         }
 
+        public Asset GetByAssetTag(string assetTag)
+        {
+            var response = _reqManager.Get(string.Format("{0}/bytag/{1}", _endPoint, assetTag));
+            var result = JsonConvert.DeserializeObject<Asset>(response);
+            return result;
+        }
+
+        public Asset GetBySerialNumber(string serialNumber)
+        {
+            var response = _reqManager.Get(string.Format("{0}/byserial/{1}", _endPoint, serialNumber));
+            var result = JsonConvert.DeserializeObject<Asset>(response);
+            return result;
+        }
     }
 }


### PR DESCRIPTION
The `bytag` and `byserial` APIs are documented here:
 - https://snipe-it.readme.io/reference#hardware-by-asset-tag
 - https://snipe-it.readme.io/reference#hardware-by-serial

I've tested bytag successfully on v4.6.7; byserial threw a 403 for me, though, so use at your own risk. It should work, according to the docs.