### PR TITLE
Get Asset By Asset Tag

### DIFF
--- a/SnipeSharp/Endpoints/EndPointManager.cs
+++ b/SnipeSharp/Endpoints/EndPointManager.cs
@@ -95,7 +95,7 @@ namespace SnipeSharp.Endpoints
         {
             string response = _reqManager.Get(_endPoint, filter);
             ResponseCollection<T> result = JsonConvert.DeserializeObject<ResponseCollection<T>>(response);
-            return (result.Rows != null) ? result.Rows[0] : default(T);
+            return (result.Rows != null && result.Rows.Count >= 1) ? result.Rows[0] : default(T);
         }
 
         /// <summary>

--- a/SnipeSharp/Endpoints/ExtendedManagers/AssetEndpointManager.cs
+++ b/SnipeSharp/Endpoints/ExtendedManagers/AssetEndpointManager.cs
@@ -27,5 +27,14 @@ namespace SnipeSharp.Endpoints.ExtendedManagers
             return result;
         }
 
+
+        public Asset GetByAssetTag(string item)
+        {
+            Asset result;
+            string response = _reqManager.Get(string.Format("{0}/bytag/{1}", _endPoint, item));
+            result = JsonConvert.DeserializeObject<Asset>(response);
+            return result;
+        }
+
     }
 }

--- a/SnipeSharp/Endpoints/Models/User.cs
+++ b/SnipeSharp/Endpoints/Models/User.cs
@@ -105,7 +105,13 @@ namespace SnipeSharp.Endpoints.Models
         public object Zip { get; set; }
 
         [RequiredRequestHeader("password")]
+        [JsonProperty("password")]
+
         public string Password { get; set; }
+
+        [RequiredRequestHeader("password_confirmation")]
+        [JsonProperty("password_confirmation")]
+        public string PasswordConfirmation { get; set; }
 
         [JsonProperty("department")]
         [OptionalRequestHeader("department_id")]


### PR DESCRIPTION
based on the Snipe-IT API documentation. We required this feature. May be useful to others.